### PR TITLE
createMock from golevelup nestjs testing tool shows vscode error on prisma client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,292 @@
+{
+  "name": "prisma-sqlite",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prisma-sqlite",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@golevelup/nestjs-testing": "^0.1.2",
+        "@prisma/client": "^3.10.0-dev.16",
+        "prisma": "^3.10.0-dev.16"
+      },
+      "devDependencies": {
+        "@types/node": "^14.14.22",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.3"
+      }
+    },
+    "node_modules/@golevelup/nestjs-testing": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz",
+      "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
+    },
+    "node_modules/@prisma/client": {
+      "version": "3.10.0-dev.16",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.10.0-dev.16.tgz",
+      "integrity": "sha512-t8uyOoGW/WQK36kbQGYZ28KVTxDtL51sJvGY0SY36KRO3/gyz+tkMXLGZTZczzkV+jXg+InKNfhOokhTxKN9kA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines-version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
+      },
+      "engines": {
+        "node": ">=12.6"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz",
+      "integrity": "sha512-l8zItOIdx4WVagPC9xNh3o2RWnVvOjq3vS/NYfat+N/uuKuMWaHIv/c4RZ72IHILi3g3NGytA5Cd8emrgI2DoA==",
+      "hasInstallScript": true
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz",
+      "integrity": "sha512-h+LjmeiDiQcpSj5SURuEjpvN971SMRqYtnwinrpAsJGfqumv8qRPj4zvo/i2Hj5DqIo5TR54dZcKo05jfjxTBA=="
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
+      "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/prisma": {
+      "version": "3.10.0-dev.16",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.10.0-dev.16.tgz",
+      "integrity": "sha512-RaHzanzVzqGUzJX71OGVfu4gn9RFp+/6Q0vzHWMCqpSiRPSXBYBxjTN96f76kOnxoluYFDUc7g31okUSMvXI+A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
+      },
+      "bin": {
+        "prisma": "build/index.js",
+        "prisma2": "build/index.js"
+      },
+      "engines": {
+        "node": ">=12.6"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "@golevelup/nestjs-testing": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz",
+      "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
+    },
+    "@prisma/client": {
+      "version": "3.10.0-dev.16",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.10.0-dev.16.tgz",
+      "integrity": "sha512-t8uyOoGW/WQK36kbQGYZ28KVTxDtL51sJvGY0SY36KRO3/gyz+tkMXLGZTZczzkV+jXg+InKNfhOokhTxKN9kA==",
+      "requires": {
+        "@prisma/engines-version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
+      }
+    },
+    "@prisma/engines": {
+      "version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz",
+      "integrity": "sha512-l8zItOIdx4WVagPC9xNh3o2RWnVvOjq3vS/NYfat+N/uuKuMWaHIv/c4RZ72IHILi3g3NGytA5Cd8emrgI2DoA=="
+    },
+    "@prisma/engines-version": {
+      "version": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz",
+      "integrity": "sha512-h+LjmeiDiQcpSj5SURuEjpvN971SMRqYtnwinrpAsJGfqumv8qRPj4zvo/i2Hj5DqIo5TR54dZcKo05jfjxTBA=="
+    },
+    "@types/node": {
+      "version": "14.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz",
+      "integrity": "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "prisma": {
+      "version": "3.10.0-dev.16",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.10.0-dev.16.tgz",
+      "integrity": "sha512-RaHzanzVzqGUzJX71OGVfu4gn9RFp+/6Q0vzHWMCqpSiRPSXBYBxjTN96f76kOnxoluYFDUc7g31okUSMvXI+A==",
+      "requires": {
+        "@prisma/engines": "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@golevelup/nestjs-testing": "^0.1.2",
+        "@golevelup/ts-jest": "^0.3.3",
         "@prisma/client": "^3.10.0-dev.16",
         "prisma": "^3.10.0-dev.16"
       },
@@ -19,10 +19,10 @@
         "typescript": "^4.1.3"
       }
     },
-    "node_modules/@golevelup/nestjs-testing": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz",
-      "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
+    "node_modules/@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q=="
     },
     "node_modules/@prisma/client": {
       "version": "3.10.0-dev.16",
@@ -179,10 +179,10 @@
     }
   },
   "dependencies": {
-    "@golevelup/nestjs-testing": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz",
-      "integrity": "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
+    "@golevelup/ts-jest": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz",
+      "integrity": "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q=="
     },
     "@prisma/client": {
       "version": "3.10.0-dev.16",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@golevelup/nestjs-testing": "^0.1.2",
+    "@golevelup/ts-jest": "^0.3.3",
     "@prisma/client": "^3.10.0-dev.16",
     "prisma": "^3.10.0-dev.16"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@golevelup/nestjs-testing": "^0.1.2",
     "@prisma/client": "^3.10.0-dev.16",
     "prisma": "^3.10.0-dev.16"
   },

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,9 +1,9 @@
-import { createMock } from "@golevelup/nestjs-testing";
+import { createMock } from "@golevelup/ts-jest";
 import { PrismaClient } from "@prisma/client";
 
 createMock<PrismaClient>({
   user: {
-    findMany(args?) {
+    findMany() {
       return Promise.resolve([]);
     }
   }

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,0 +1,10 @@
+import { createMock } from "@golevelup/nestjs-testing";
+import { PrismaClient } from "@prisma/client";
+
+createMock<PrismaClient>({
+  user: {
+    findMany(args?) {
+      return Promise.resolve([]);
+    }
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@golevelup/nestjs-testing@^0.1.2":
-  "integrity" "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
-  "resolved" "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz"
-  "version" "0.1.2"
+"@golevelup/ts-jest@^0.3.3":
+  "integrity" "sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q=="
+  "resolved" "https://registry.npmjs.org/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz"
+  "version" "0.3.3"
 
 "@prisma/client@^3.10.0-dev.16":
   "integrity" "sha512-t8uyOoGW/WQK36kbQGYZ28KVTxDtL51sJvGY0SY36KRO3/gyz+tkMXLGZTZczzkV+jXg+InKNfhOokhTxKN9kA=="

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,91 +2,96 @@
 # yarn lockfile v1
 
 
+"@golevelup/nestjs-testing@^0.1.2":
+  "integrity" "sha512-7TOpI6E86GBE93DJoCqavOfycAMPjnZDfcpdBrm/aWUoR/oDxHjhTr1R8NGVY4+iHY5wDwEXG7mcDkDEWQznfQ=="
+  "resolved" "https://registry.npmjs.org/@golevelup/nestjs-testing/-/nestjs-testing-0.1.2.tgz"
+  "version" "0.1.2"
+
 "@prisma/client@^3.10.0-dev.16":
-  version "3.10.0-dev.16"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.10.0-dev.16.tgz#aaa502f826ce459b3090808670c4ce7009245587"
-  integrity sha512-t8uyOoGW/WQK36kbQGYZ28KVTxDtL51sJvGY0SY36KRO3/gyz+tkMXLGZTZczzkV+jXg+InKNfhOokhTxKN9kA==
+  "integrity" "sha512-t8uyOoGW/WQK36kbQGYZ28KVTxDtL51sJvGY0SY36KRO3/gyz+tkMXLGZTZczzkV+jXg+InKNfhOokhTxKN9kA=="
+  "resolved" "https://registry.npmjs.org/@prisma/client/-/client-3.10.0-dev.16.tgz"
+  "version" "3.10.0-dev.16"
   dependencies:
     "@prisma/engines-version" "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
 
 "@prisma/engines-version@3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e":
-  version "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz#81ee4f59a22298d268ff8195aea8d301b6d6d7b1"
-  integrity sha512-h+LjmeiDiQcpSj5SURuEjpvN971SMRqYtnwinrpAsJGfqumv8qRPj4zvo/i2Hj5DqIo5TR54dZcKo05jfjxTBA==
+  "integrity" "sha512-h+LjmeiDiQcpSj5SURuEjpvN971SMRqYtnwinrpAsJGfqumv8qRPj4zvo/i2Hj5DqIo5TR54dZcKo05jfjxTBA=="
+  "resolved" "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz"
+  "version" "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
 
 "@prisma/engines@3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e":
-  version "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz#bd70f6e4f837400f62c2a68514f8906c081f7fe2"
-  integrity sha512-l8zItOIdx4WVagPC9xNh3o2RWnVvOjq3vS/NYfat+N/uuKuMWaHIv/c4RZ72IHILi3g3NGytA5Cd8emrgI2DoA==
+  "integrity" "sha512-l8zItOIdx4WVagPC9xNh3o2RWnVvOjq3vS/NYfat+N/uuKuMWaHIv/c4RZ72IHILi3g3NGytA5Cd8emrgI2DoA=="
+  "resolved" "https://registry.npmjs.org/@prisma/engines/-/engines-3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e.tgz"
+  "version" "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
 
 "@types/node@^14.14.22":
-  version "14.18.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.10.tgz#774f43868964f3cfe4ced1f5417fe15818a4eaea"
-  integrity sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ==
+  "integrity" "sha512-6iihJ/Pp5fsFJ/aEDGyvT4pHGmCpq7ToQ/yf4bl5SbVAvwpspYJ+v3jO7n8UyjhQVHTy+KNszOozDdv+O6sovQ=="
+  "resolved" "https://registry.npmjs.org/@types/node/-/node-14.18.10.tgz"
+  "version" "14.18.10"
 
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+"arg@^4.1.0":
+  "integrity" "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+  "resolved" "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
+  "version" "4.1.3"
 
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+"buffer-from@^1.0.0":
+  "integrity" "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+  "resolved" "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
+  "version" "1.1.2"
 
-create-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
-  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+"create-require@^1.1.0":
+  "integrity" "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+  "resolved" "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
+  "version" "1.1.1"
 
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+"diff@^4.0.1":
+  "integrity" "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+  "resolved" "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
+  "version" "4.0.2"
 
-make-error@^1.1.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+"make-error@^1.1.1":
+  "integrity" "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+  "resolved" "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
+  "version" "1.3.6"
 
-prisma@^3.10.0-dev.16:
-  version "3.10.0-dev.16"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.10.0-dev.16.tgz#5b27c2ded10810f294a71914f97bf7f704825df0"
-  integrity sha512-RaHzanzVzqGUzJX71OGVfu4gn9RFp+/6Q0vzHWMCqpSiRPSXBYBxjTN96f76kOnxoluYFDUc7g31okUSMvXI+A==
+"prisma@*", "prisma@^3.10.0-dev.16":
+  "integrity" "sha512-RaHzanzVzqGUzJX71OGVfu4gn9RFp+/6Q0vzHWMCqpSiRPSXBYBxjTN96f76kOnxoluYFDUc7g31okUSMvXI+A=="
+  "resolved" "https://registry.npmjs.org/prisma/-/prisma-3.10.0-dev.16.tgz"
+  "version" "3.10.0-dev.16"
   dependencies:
     "@prisma/engines" "3.10.0-12.60b16207c02de858be08e861ddaf1739c77eb43e"
 
-source-map-support@^0.5.17:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+"source-map-support@^0.5.17":
+  "integrity" "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="
+  "resolved" "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  "version" "0.5.21"
   dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
+    "buffer-from" "^1.0.0"
+    "source-map" "^0.6.0"
 
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+"source-map@^0.6.0":
+  "integrity" "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+  "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  "version" "0.6.1"
 
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+"ts-node@^9.1.1":
+  "integrity" "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg=="
+  "resolved" "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz"
+  "version" "9.1.1"
   dependencies:
-    arg "^4.1.0"
-    create-require "^1.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
+    "arg" "^4.1.0"
+    "create-require" "^1.1.0"
+    "diff" "^4.0.1"
+    "make-error" "^1.1.1"
+    "source-map-support" "^0.5.17"
+    "yn" "3.1.1"
 
-typescript@^4.1.3:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+"typescript@^4.1.3", "typescript@>=2.7":
+  "integrity" "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+  "resolved" "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz"
+  "version" "4.5.5"
 
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+"yn@3.1.1":
+  "integrity" "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+  "resolved" "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
+  "version" "3.1.1"


### PR DESCRIPTION
Related slack: https://prisma.slack.com/archives/CA491RJH0/p1662579286369399

- Created a `test` direcotry
- In the directory, created a `user.test.ts`
- Used `CreateMock` from golevelup nestjst testing package

In vscode it shows error
![image](https://user-images.githubusercontent.com/1134397/192123411-294eb1ad-03ad-4e6f-87d0-b24a73b959ec.png)

Error message
```
Type '<T extends UserFindManyArgs>(args?: SelectSubset<T, UserFindManyArgs> | undefined) => Promise<never[]>' is not assignable to type '<T extends UserFindManyArgs>(args?: SelectSubset<T, UserFindManyArgs> | undefined) => CheckSelect<T, PrismaPromise<User[]>, PrismaPromise<...>>'.
  Type 'Promise<never[]>' is not assignable to type 'CheckSelect<T, PrismaPromise<User[]>, PrismaPromise<UserGetPayload<T, keyof T>[]>>'.ts(2322)
```